### PR TITLE
Planets: Clean up brinstar

### DIFF
--- a/randovania/games/metroid/json_data/Brinstar.json
+++ b/randovania/games/metroid/json_data/Brinstar.json
@@ -3,14 +3,14 @@
     "extra": {},
     "areas": {
         "Corridor 1": {
-            "default_node": "Spawn Point",
+            "default_node": "Starting Point",
             "extra": {
                 "map_name": "Brinstar/x47_y202"
             },
             "nodes": {
-                "Spawn Point": {
+                "Starting Point": {
                     "node_type": "generic",
-                    "heal": false,
+                    "heal": true,
                     "coordinates": {
                         "x": 440.0,
                         "y": 64.0,
@@ -27,6 +27,13 @@
                     "valid_starting_location": true,
                     "connections": {
                         "Pickup (Morph Ball)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Fake Block shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -54,7 +61,7 @@
                     "pickup_index": 0,
                     "location_category": "major",
                     "connections": {
-                        "Door to Fake Block shaft": {
+                        "Starting Point": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -108,14 +115,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Spawn Point": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Pickup (Morph Ball)": {
+                        "Starting Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -206,8 +206,11 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Corridor 1": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -810,8 +813,13 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "resource",
@@ -868,14 +876,28 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Hi-Jump",
+                                            "type": "events",
+                                            "name": "Event1",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event2",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1115,8 +1137,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 128.0,
-                        "y": 1144.0,
+                        "x": 123.22088933853644,
+                        "y": 1218.4940020234137,
                         "z": 0.0
                     },
                     "description": "",
@@ -1183,7 +1205,14 @@
                     "pickup_index": 9,
                     "location_category": "major",
                     "connections": {
-                        "Center of room": {
+                        "Door to Gold-colored shaft": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Transport to Norfair": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1218,7 +1247,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Center of room": {
+                        "Pickup (Missile Launcher)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1253,45 +1282,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Center of room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Center of room": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1144.0,
-                        "y": 148.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "valid_starting_location": false,
-                    "connections": {
                         "Pickup (Missile Launcher)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Gold-colored shaft": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Transport to Norfair": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2446,7 +2437,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Bomb Block shaft (Right)": {
+                        "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2481,13 +2472,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to End shaft": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
@@ -2516,6 +2500,13 @@
                     "pickup_index": 7,
                     "location_category": "minor",
                     "connections": {
+                        "Door to End shaft": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Door to Bomb Block shaft (Right)": {
                             "type": "and",
                             "data": {
@@ -2565,13 +2556,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Secret Path": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -2607,10 +2591,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Secret Path": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
                         }
                     }
                 },
@@ -2634,6 +2614,13 @@
                     "location_category": "minor",
                     "connections": {
                         "Door to Corridor-connecting room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Secret Path": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2667,6 +2654,18 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Secret Path": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -2685,11 +2684,19 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Corridor-connecting room": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                        "Pickup (Missile Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    }
+                                ]
+                            }
                         },
-                        "Door to End shaft": {
+                        "Pickup (Energy Tank)": {
                             "type": "template",
                             "data": "Can Use Bombs"
                         }
@@ -2956,10 +2963,29 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Bridge": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Hi-Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Ice Beam",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/metroid/json_data/Brinstar.txt
+++ b/randovania/games/metroid/json_data/Brinstar.txt
@@ -1,26 +1,26 @@
 ----------------
 Corridor 1
 Extra - map_name: Brinstar/x47_y202
-> Spawn Point; Heals? False; Spawn Point; Default Node
+> Starting Point; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - global_x: 648
   * Extra - global_y: 3296
   > Pickup (Morph Ball)
+      Trivial
+  > Door to Fake Block shaft
       Trivial
 
 > Pickup (Morph Ball); Heals? False
   * Layers: default
   * Pickup 0; Category? Major
   * Extra - object_id: 100018
-  > Door to Fake Block shaft
+  > Starting Point
       Hi-Jump Boots or Morph Ball
 
 > Door to Fake Block shaft; Heals? False
   * Layers: default
   * Normal Door to Fake Block shaft/Door to Corridor 1
-  > Spawn Point
-      Trivial
-  > Pickup (Morph Ball)
+  > Starting Point
       Trivial
 
 ----------------
@@ -38,7 +38,7 @@ Extra - map_name: Brinstar/x88_y233
   * Layers: default
   * Normal Door to Kraid Elevator/Door to Fake Block shaft
   > Door to Corridor 1
-      Can Use Bombs
+      Trivial
 
 > Door to Overhang corridor; Heals? False
   * Layers: default
@@ -154,13 +154,13 @@ Extra - map_name: Brinstar/x56_y22
   * Layers: default
   * Missile Door to Corridor 2/Door to Entrance to Tourian
   > Door to Transport to Tourian
-      After Kraid Boss Killed and After Ridley Boss Killed and Can Use Bombs
+      Morph Ball and After Kraid Boss Killed and After Ridley Boss Killed
 
 > Door to Transport to Tourian; Heals? False
   * Layers: default
   * Normal Door to Transport to Tourian/Door to Entrance to Tourian
   > Door to Corridor 2
-      Hi-Jump Boots and Can Use Bombs
+      Morph Ball and After Kraid Boss Killed and After Ridley Boss Killed
 
 ----------------
 Vestibule
@@ -222,28 +222,21 @@ Extra - map_name: Brinstar/x272_y157
   * Layers: default
   * Pickup 9; Category? Major
   * Extra - object_id: 100035
-  > Center of room
+  > Door to Gold-colored shaft
+      Trivial
+  > Door to Transport to Norfair
       Trivial
 
 > Door to Gold-colored shaft; Heals? False
   * Layers: default
   * Normal Door to Gold-colored shaft/Door to Corridor 5
-  > Center of room
+  > Pickup (Missile Launcher)
       Trivial
 
 > Door to Transport to Norfair; Heals? False
   * Layers: default
   * Normal Door to Transport to Norfair/Door to Corridor 5
-  > Center of room
-      Trivial
-
-> Center of room; Heals? False
-  * Layers: default
   > Pickup (Missile Launcher)
-      Trivial
-  > Door to Gold-colored shaft
-      Trivial
-  > Door to Transport to Norfair
       Trivial
 
 ----------------
@@ -476,14 +469,12 @@ Extra - map_name: Brinstar/x464_y97
 > Door to End shaft; Heals? False
   * Layers: default
   * Normal Door to End shaft/Door to Corridor 6
-  > Door to Bomb Block shaft (Right)
+  > Pickup (Energy Tank)
       Trivial
 
 > Door to Bomb Block shaft (Right); Heals? False
   * Layers: default
   * Normal Door to Bomb Block shaft (Right)/Door to Corridor 6
-  > Door to End shaft
-      Trivial
   > Pickup (Energy Tank)
       Trivial
 
@@ -491,6 +482,8 @@ Extra - map_name: Brinstar/x464_y97
   * Layers: default
   * Pickup 7; Category? Minor
   * Extra - object_id: 100033
+  > Door to End shaft
+      Trivial
   > Door to Bomb Block shaft (Right)
       Trivial
 
@@ -502,22 +495,20 @@ Extra - map_name: Brinstar/x392_y37
   * Normal Door to Corridor-connecting room/Door to Corridor 7
   > Pickup (Missile Tank)
       Trivial
-  > Secret Path
-      Trivial
 
 > Door to End shaft; Heals? False
   * Layers: default
   * Normal Door to End shaft/Door to Corridor 7
   > Pickup (Energy Tank)
       Trivial
-  > Secret Path
-      Can Use Bombs
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 4; Category? Minor
   * Extra - object_id: 100030
   > Door to Corridor-connecting room
+      Trivial
+  > Secret Path
       Trivial
 
 > Pickup (Energy Tank); Heals? False
@@ -526,12 +517,14 @@ Extra - map_name: Brinstar/x392_y37
   * Extra - object_id: 100031
   > Door to End shaft
       Trivial
+  > Secret Path
+      Can Use Bombs
 
 > Secret Path; Heals? False
   * Layers: default
-  > Door to Corridor-connecting room
+  > Pickup (Missile Tank)
       Can Use Bombs
-  > Door to End shaft
+  > Pickup (Energy Tank)
       Can Use Bombs
 
 ----------------
@@ -583,7 +576,7 @@ Extra - map_name: Brinstar/x344_y113
   * Layers: default
   * Normal Door to Cavernous hall/Door to Bomb Block shaft (Right)
   > Bridge
-      Trivial
+      Hi-Jump Boots or Ice Beam
 
 > Bridge; Heals? False
   * Layers: default

--- a/randovania/games/metroid/json_data/header.json
+++ b/randovania/games/metroid/json_data/header.json
@@ -194,7 +194,7 @@
     "starting_location": {
         "region": "Brinstar",
         "area": "Corridor 1",
-        "node": "Spawn Point"
+        "node": "Starting Point"
     },
     "initial_states": {
         "Default": []


### PR DESCRIPTION
- Rename "Spawn Point" to "Starting Point" to be more clearer.
- Fix traversal in morph ball room between nodes
- Fix going up from kraid requirigin bombs
- Change tourian boss checks to be like it was discussed for patcher to change them
- remove unnecessary helper nodes if there are pickup nodes nearby
- fix coming out of shaft in ice 